### PR TITLE
Fixing featured docs slideshow width.

### DIFF
--- a/docroot/sites/all/themes/shelter/assets/javascripts/featured-docs.js
+++ b/docroot/sites/all/themes/shelter/assets/javascripts/featured-docs.js
@@ -1,51 +1,54 @@
 (function ($) {
   Drupal.behaviors.shelterFeaturedDocs = {
     attach: function (context, settings) {
-      $('#featured-documents').once('shelterFeaturedDocs', function() {
-        var carousel = $('.featured-document-slider');
-        carousel.jcarousel();
 
-        carousel.on('jcarousel:create jcarousel:reload', function() {
-          var element = $(this),
-          width = element.innerWidth();
-          element.jcarousel('items').css('width', width + 'px');
-        });
+      var carousel = $('.featured-document-slider', context);
+      carousel.jcarousel();
 
-        carousel.jcarouselAutoscroll({
-          interval: 5000
-        });
-
-        $('.jcarousel-control-prev')
-          .on('jcarouselcontrol:active', function() {
-              $(this).removeClass('inactive');
-          })
-          .on('jcarouselcontrol:inactive', function() {
-              $(this).addClass('inactive');
-          })
-          .jcarouselControl({
-              target: '-=1'
-          });
-
-        $('.jcarousel-control-next')
-          .on('jcarouselcontrol:active', function() {
-              $(this).removeClass('inactive');
-          })
-          .on('jcarouselcontrol:inactive', function() {
-              $(this).addClass('inactive');
-          })
-          .jcarouselControl({
-              target: '+=1'
-          });
-
-        $('.jcarousel-pagination')
-          .on('jcarouselpagination:active', 'a', function() {
-              $(this).addClass('active');
-          })
-          .on('jcarouselpagination:inactive', 'a', function() {
-              $(this).removeClass('active');
-          })
-          .jcarouselPagination();
+      carousel.on('jcarousel:reload', function() {
+        var totalWidth = $('#content', context).innerWidth();
+        var sideColumn = $('.side-column', context).outerWidth(true);
+        var width = totalWidth - sideColumn;
+        carousel.css('width', width + 'px');
+        carousel.jcarousel('items').css('width', width + 'px');
       });
+      carousel.trigger('jcarousel:reload');
+
+      carousel.jcarouselAutoscroll({
+        interval: 5000
+      });
+
+      $('.jcarousel-control-prev', context)
+        .on('jcarouselcontrol:active', function() {
+            $(this).removeClass('inactive');
+        })
+        .on('jcarouselcontrol:inactive', function() {
+            $(this).addClass('inactive');
+        })
+        .jcarouselControl({
+            target: '-=1'
+        });
+
+      $('.jcarousel-control-next', context)
+        .on('jcarouselcontrol:active', function() {
+            $(this).removeClass('inactive');
+        })
+        .on('jcarouselcontrol:inactive', function() {
+            $(this).addClass('inactive');
+        })
+        .jcarouselControl({
+            target: '+=1'
+        });
+
+      $('.jcarousel-pagination', context)
+        .on('jcarouselpagination:active', 'a', function() {
+            $(this).addClass('active');
+        })
+        .on('jcarouselpagination:inactive', 'a', function() {
+            $(this).removeClass('active');
+        })
+        .jcarouselPagination();
+
     }
   };
 })(jQuery);


### PR DESCRIPTION
- Removed .once() and add proper context to jquery selectors.
- Calculating slideshow width based on the page width minus the sidebar, if we just use 100% it will be bigger than expected, I think the slideshow needs a base width to be built, and the browser needs a base width too for display: flex.