### PR TITLE
Populating document title with uploaded file name.

### DIFF
--- a/docroot/sites/all/modules/custom/cluster_docs/cluster_docs.admin.inc
+++ b/docroot/sites/all/modules/custom/cluster_docs/cluster_docs.admin.inc
@@ -43,6 +43,7 @@ function cluster_docs_menu_alter(&$items) {
  */
 function cluster_docs_form_document_node_form_alter(&$form, &$form_state, $form_id) {
   $form['#validate'][] = 'cluster_docs_validate';
+  $form['#attached']['js'][] = drupal_get_path('module', 'cluster_docs') . '/js/populate_title.js';
 }
 
 /**

--- a/docroot/sites/all/modules/custom/cluster_docs/js/populate_title.js
+++ b/docroot/sites/all/modules/custom/cluster_docs/js/populate_title.js
@@ -1,0 +1,15 @@
+(function ($) {
+  Drupal.behaviors.cluster_docs_admin_title = {
+    attach: function (context, settings) {
+      var $file = $('.field-name-field-file .file-widget .file a', context);
+      var $title = $('.form-item-title input', context);
+
+      // This doesn't work with context because ajax will trigger it again, we
+      // add once here to the ajax response, so it loads once per ajax response.
+      $file.once('shelter-title', function() {
+        var title = $file.text().replace(/\.[^/.]+$/, "");
+        $title.val(title);
+      });
+    }
+  }
+})(jQuery);


### PR DESCRIPTION
This one is a bit tricky, I didn't add a ajax listener because there is no reason too, since the js is attached to the form, it reloads on every ajax call, I couldn't also use context on javascript because (I think) it doesn't makes sense in this case, so instead I used once() on the ajax result html, this way we make sure the naming thing only runs once per page load (or ajax load).